### PR TITLE
refactor: PaymentService @Valid  삭제

### DIFF
--- a/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
+++ b/backend/src/main/java/com/backend/domain/payment/service/PaymentService.java
@@ -74,7 +74,7 @@ public class PaymentService {
 
     // 결제 단건 취소 - controller
     @Transactional
-    public PaymentCancelResponse cancelPayment(@Valid Long paymentId, UserDto currentUser) {
+    public PaymentCancelResponse cancelPayment(Long paymentId, UserDto currentUser) {
         if (paymentId == null || paymentId <= 0) {
             throw new BusinessException(ErrorCode.NOT_FOUND_PAYMENT);
         }
@@ -109,7 +109,7 @@ public class PaymentService {
 
     // 취소된 결제 내역 삭제 - controller
     @Transactional
-    public void deletePayment(@Valid Long paymentId, UserDto currentUser) {
+    public void deletePayment(Long paymentId, UserDto currentUser) {
         if (paymentId == null || paymentId <= 0) {
             throw new BusinessException(ErrorCode.NOT_FOUND_PAYMENT);
         }


### PR DESCRIPTION
1. PaymentService @Valid  삭제
@Valid는 객체의 필드에 대한 검증을 수행하는데, Long은 원시 타입 래퍼 클래스라서 내부 필드가 없고, @NotNull, @Min 같은 제약 조건을 Long 자체에 붙일 수 없음
